### PR TITLE
Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ go get -u github.com/DevMine/ght2dm
 
 ## Usage
 
+*IMPORTANT:* Make sure to run the script in `db/create_tmp_table.sql` before
+running `ght2dm`. The latter assuems that this table is created and empty. Note
+that this script is useful only when importing `repositories`.
+
 `ght2dm` usage is pretty simple: it only requires to pass a configuration file
 as argument:
 
@@ -66,4 +70,3 @@ The currently supported entities are:
 
 Each `bson` dump must be named according to its creation date and using the
 format `yyyy-mm-dd`. Files that does not respect this convention are skipped.
-

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go get -u github.com/DevMine/ght2dm
 ## Usage
 
 *IMPORTANT:* Make sure to run the script in `db/create_tmp_table.sql` before
-running `ght2dm`. The latter assuems that this table is created and empty. Note
+running `ght2dm`. The latter assumes that this table is created and empty. Note
 that this script is useful only when importing `repositories`.
 
 `ght2dm` usage is pretty simple: it only requires to pass a configuration file

--- a/db/create_tmp_tables.sql
+++ b/db/create_tmp_tables.sql
@@ -1,0 +1,33 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+DROP TABLE IF EXISTS tmp_gh_repositories;
+
+CREATE TABLE tmp_gh_repositories (
+    name character varying NOT NULL,
+    primary_language character varying NOT NULL,
+    clone_url character varying NOT NULL,
+    clone_path character varying NOT NULL,
+    vcs character varying NOT NULL,
+    github_id bigint NOT NULL,
+    full_name character varying,
+    description character varying,
+    homepage character varying,
+    fork boolean,
+    default_branch character varying,
+    master_branch character varying,
+    html_url character varying,
+    forks_count integer,
+    open_issues_count integer,
+    stargazers_count integer,
+    subscribers_count integer,
+    watchers_count integer,
+    size_in_kb integer,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    pushed_at timestamp with time zone
+);

--- a/db/insert_from_tmp_tables.sql
+++ b/db/insert_from_tmp_tables.sql
@@ -1,0 +1,85 @@
+-- insert repos into repositories and gh_repositories from tmp_gh_repositories table
+CREATE OR REPLACE FUNCTION insert_repos() RETURNS void AS
+$BODY$
+DECLARE
+    repo_id repositories.id%TYPE;
+    repo tmp_gh_repositories%ROWTYPE;
+BEGIN
+    FOR repo IN
+        -- get all non already inserted repositories, without duplicates
+        SELECT DISTINCT
+            tgr.name,
+            tgr.primary_language,
+            tgr.clone_url,
+            tgr.clone_path,
+            tgr.vcs,
+            tgr.github_id,
+            tgr.full_name,
+            tgr.description,
+            tgr.homepage,
+            tgr.fork,
+            tgr.default_branch,
+            tgr.master_branch,
+            tgr.html_url,
+            tgr.forks_count,
+            tgr.open_issues_count,
+            tgr.stargazers_count,
+            tgr.subscribers_count,
+            tgr.watchers_count,
+            tgr.size_in_kb,
+            tgr.created_at,
+            tgr.updated_at,
+            tgr.pushed_at
+        FROM tmp_gh_repositories AS tgr
+        INNER JOIN (
+            SELECT
+                clone_path,
+                max(updated_at) AS max_updated_at,
+                max(pushed_at) AS max_pushed_at,
+                min(open_issues_count) AS max_open_issues_count
+            FROM tmp_gh_repositories
+            GROUP BY clone_path) AS tmp ON (
+                tmp.clone_path = tgr.clone_path AND
+                tmp.max_updated_at = tgr.updated_at AND
+                tmp.max_pushed_at = tgr.pushed_at AND
+                tmp.max_open_issues_count = tgr.open_issues_count
+            )
+        LEFT JOIN gh_repositories AS gr ON tgr.github_id = gr.github_id
+        LEFT JOIN repositories AS r ON tgr.clone_path = r.clone_path
+        WHERE gr.id IS NULL AND r.id IS NULL AND tgr.clone_url <> '' AND tgr.clone_path <> '' AND tgr.primary_language <> ''
+    LOOP
+        -- raise notice 'Value: %', repo;
+
+        -- create repositories
+        INSERT INTO repositories (name, primary_language, clone_url, clone_path, vcs)
+        VALUES (repo.name, repo.primary_language, repo.clone_url, repo.clone_path, repo.vcs)
+        RETURNING id INTO repo_id;
+
+        -- create gh_repositories
+        INSERT INTO gh_repositories (repository_id, github_id, full_name, description, homepage, fork, default_branch, master_branch, html_url, forks_count, open_issues_count, stargazers_count, subscribers_count, watchers_count, size_in_kb, created_at, updated_at, pushed_at)
+        VALUES(
+            repo_id,
+            repo.github_id,
+            repo.full_name,
+            repo.description,
+            repo.homepage,
+            repo.fork,
+            repo.default_branch,
+            repo.master_branch,
+            repo.html_url,
+            repo.forks_count,
+            repo.open_issues_count,
+            repo.stargazers_count,
+            repo.subscribers_count,
+            repo.watchers_count,
+            repo.size_in_kb,
+            repo.created_at,
+            repo.updated_at,
+            repo.pushed_at
+        );
+    END LOOP;
+END
+$BODY$
+LANGUAGE plpgsql;
+
+SELECT insert_repos();


### PR DESCRIPTION
The GH Torrent dumps for repositories are really big (from few GB to 17 GB) which makes the insertion into the DevMine database really slow. This PR brings a real optimization: instead of directly inserting data into the repositories and gh_repositories tables, it inserts them into a temporary table. This makes insertions really fast since there are no constraints, no foreign keys and no indexes. After that, it is needed to run a small SQL script to insert repositories into the repositories and gh_repositories tables from the temporary table. The usage of JOIN instead of massive SELECT queries to avoid duplicates greatly improves performances.

Please, review my changes with care.
